### PR TITLE
[Feat] 강의 상세 페이지 FE & BE 연결

### DIFF
--- a/IntegrateLecture/IntegrateLecture/settings.py
+++ b/IntegrateLecture/IntegrateLecture/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 
 from pathlib import Path
 import environ
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/IntegrateLecture/IntegrateLecture/urls.py
+++ b/IntegrateLecture/IntegrateLecture/urls.py
@@ -34,9 +34,9 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     #swagger
-    re_path(r'swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+    re_path(r'swagger(?P<format>\.json|\.yaml)/$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
     re_path(r'swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-    re_path(r'redoc', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc-v1'),
+    re_path(r'redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc-v1'),
     
     #apps
     path('', include('lecture.urls')),

--- a/IntegrateLecture/lecture/models.py
+++ b/IntegrateLecture/lecture/models.py
@@ -19,6 +19,7 @@ class LectureInfo(models.Model):
     price = models.IntegerField(blank=True, null=True)
     description = models.TextField(blank=True, null=True)
     tag = models.CharField(max_length=255, blank=True, null=True)
+    what_do_i_learn = models.TextField(blank=True, null=True)
     level = models.CharField(max_length=255, blank=True, null=True)
     teacher = models.CharField(max_length=255, blank=True, null=True)
     scope = models.FloatField(blank=True, null=True)
@@ -44,7 +45,7 @@ class CategoryConn(models.Model):
     )
 
     class Meta:
-        managed = False
+        managed = True
         db_table = "Category_conn"
 
 

--- a/IntegrateLecture/lecture/static/css/detail_body.css
+++ b/IntegrateLecture/lecture/static/css/detail_body.css
@@ -1,0 +1,329 @@
+/*************************************************************/
+/* 텝 섹션 */
+.tab-container {
+    display: flex;
+    justify-content: center;
+    position: sticky;
+    top: 0; /* tab-container를 상단에 고정 */
+    background: #f3f3f3;
+    z-index: 1000;
+    border-bottom: 2px solid #ddd;
+}
+
+.tab-button {
+    flex: 1;
+    padding: 10px 20px;
+    cursor: pointer;
+    background: #fff;
+    border: none;
+    border-bottom: 3px solid transparent;
+    font-size: 16px;
+    transition: border-color 0.3s;
+}
+
+.tab-button:hover,
+.tab-button.active {
+    border-bottom: 3px solid #424769;
+}
+
+/*************************************************************/
+/* 강의 정보 요약 섹션 */
+.lecture-summary {
+    display: flex;
+    position: absolute;
+    top: 80px;
+    left: 0;
+    flex-direction: row;
+    width: 100%;
+    height: 50%;
+    background: linear-gradient(to right, #23273e, #646883); /* 연한 네이비색 그라데이션 */
+    padding: 20px;
+    box-sizing: border-box;
+}
+
+.summary-info {
+    display: flex;
+    flex-direction: column;
+    flex: 2;
+    margin-top : 45px;
+    margin-left: 100px;
+    margin-right: 50px;
+    margin-bottom: 80px;
+
+}
+
+.summary-info h1 {
+    font-size: 28px;
+    margin-bottom: 20px;
+    color: #fff; /* 하얀색 글씨 */
+}
+
+.summary-info p {
+    margin-bottom: 10px;
+    line-height: 1.5; /* 줄 간격 증가 */
+    color: #fff; /* 하얀색 글씨 */
+}
+
+.summary-info ul {
+    list-style: none; /* 기본 리스트 스타일 제거 */
+    padding: 0;
+}
+
+.summary-info ul li {
+    color: #fff; /* 하얀색 글씨 */
+}
+
+/*************************************************************/
+/* 별점 아이콘 스타일 */
+.rating-stars {
+    font-size: 1.0rem; /* 별 크기 조정 */
+}
+
+.rating-stars .fa-star,
+.rating-stars .fa-star-half-stroke {
+    color: #FFD700; /* 채워진 별의 색상: 노란색 */
+}
+
+.rating-stars .fa-star-regular {
+    color: #cdcdcd; /* 빈 별의 색상: 회색 */
+}
+
+.tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 7px; /* 버튼 간 간격 조절 */
+    margin-top: 10px; /* 상단 여백 추가 */
+}
+
+.tags button {
+    background: #001f3f;
+    color: white;
+    border: none;
+    padding: 5px 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+
+.tags button:hover {
+    background: #00132e;
+}
+
+/*************************************************************/
+/* 썸네일 섹션 */
+.lecture-thumbnail {
+    flex: 1.2;
+    text-align: center;
+}
+
+.lecture-thumbnail img {
+    width: 90%;
+    height: auto;
+    margin-top : 40px;
+    margin-right: 40px;
+    margin-bottom: 40px;
+    border-radius: 10px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+
+/*************************************************************/
+/* 세부정보 + 스티키 카드 컨테이너*/
+.lecture-content {
+    display: flex;
+    margin-top: 350px; 
+    right: 0;
+    width: 100%;
+    background: #fff;
+}
+/* 강의 세부 정보 섹션 */
+.lecture-detail {
+    margin: 20px;
+    width: 65%; /* 화면의 2/3 */
+    padding: 20px 80px; /* 여백 추가 */
+    box-sizing: border-box;
+    display: block;
+   
+}
+
+.lecture-description, .lecture-review, .lecture-price-history, .lecture-whatlearn{
+    margin: 20px 0px;
+    border-bottom: 4px solid #ededed;
+    padding-top: 30px;
+    padding-bottom: 30px;
+}
+#what-do-i-learn-container .item {
+    margin-bottom: 15px;
+    padding: 15px;
+    border: none;
+    border-radius: 10px;
+    background-color: #f2f6ff;
+}
+
+
+/*************************************************************/
+/* 따라오는 카드 정보 섹션 */
+.sticky-container {
+    position: sticky; /* 표준 브라우저 */
+    width: 28%; 
+    height: 440px;
+    display: block;
+    top: 50px;
+    margin-right: 20px;
+}
+
+.sticky-title {
+    background: #f74e6a;
+    padding: 10px;
+    border-radius: 15px 15px 0px 0px;
+    width: 100%; 
+    height: 10%;
+    display: block;
+    top: 50px;
+    text-align: center;
+}
+
+.sticky-text {
+    padding: 10px;
+    border: 1.5px solid #e7e7e7;
+    background-color: #f3f3f3;
+    width: 100%; 
+    height: 43%;
+    display: block;
+    font-size : 15px
+    
+}
+
+.info-discript {
+    display: flex;
+    align-items: center; /* 수직 가운데 정렬 */
+    justify-content: space-between; /* 공간 분배 */
+    font-size: small; /* 글씨 크기 조정 */
+    padding: 20px 10px;
+}
+.price {
+    font-size: 30px;
+    font-weight: bold;
+}
+
+#heart-icon,
+#sticky-heart-icon,
+#header-heart-icon {
+    font-size: 24px;
+    cursor: pointer;
+    transition: color 0.3s;
+}
+
+#heart-icon.liked,
+#sticky-heart-icon.liked,
+#header-heart-icon.liked {
+    color: #f92929;
+}
+
+
+.sticky-text .info {
+    color: #6e6e6e;
+    padding: 10px;
+}
+
+.sticky-button {
+    display: flex;
+    flex-direction:column;
+    padding : 20px;
+    width: 100%;
+    height: 60%;
+    border: 1.5px solid #e7e7e7;
+    background-color: #ffffff;
+    border-radius: 0px 0px 8px 8px;
+    align-items: center;
+    justify-content: center; /* 수평 가운데 정렬 */
+
+}
+
+.sticky-button .num1 {
+    display: block;
+    width: 80%;
+    height: 30%;
+    margin: 10px;
+    background: #424769;
+    border: 1.5px solid #424769;
+    color: white;
+    border-radius: 30px;
+    font-weight: 600;
+    font-size: 20px;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+
+.sticky-button .num2 {
+    display: block;
+    width: 80%;
+    height: 30%;
+    margin: 10px;
+    background: #ffffff;
+    border: 1.5px solid #424769;
+    color: #1b1b1b;
+    border-radius: 30px;
+    font-weight: 600;
+    font-size: 20px;
+    cursor: pointer;
+    transition: background 0.3s;
+}
+
+
+.sticky-button .num1:hover {
+    background: #00132e;
+}
+.sticky-button .num2:hover {
+    background: #d1d2e0;
+}
+
+
+/*************************************************************/
+/* 하단 고정 버튼 */
+.fixed-card {
+    display: none;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background: #fff;
+    border-top: 1px solid #ddd;
+    box-shadow: 0 -2px 4px rgba(0,0,0,0.1);
+    padding: 10px;
+    box-sizing: border-box;
+    z-index: 1000;
+    text-align: center;
+}
+
+.fixed-card button {
+    background: #424769;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    border-radius: 30px;
+    cursor: pointer;
+    margin: 10px 30px;
+    transition: background 0.3s;
+}
+
+.fixed-buttons button:hover {
+    background: #00132e;
+}
+
+/* 반응형 디자인 */
+@media (max-width: 1024px) {
+    .lecture-detail, .sticky-container {
+        width: 100%;
+    }
+    
+    .sticky-container {
+        display: none; /* 화면이 줄어들면 숨김 */
+    }
+    
+    .fixed-card {
+        display: block; /* 하단 고정 버튼 표시 */
+    }
+}
+
+

--- a/IntegrateLecture/lecture/static/css/detail_header.css
+++ b/IntegrateLecture/lecture/static/css/detail_header.css
@@ -1,0 +1,93 @@
+/* 공통 스타일 */
+header {
+    background: #fff; 
+    color: #000;
+    padding: 20px 50px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #c4c2c2;
+}
+
+.header-container {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.logo-container {
+    flex: 2;
+    display: flex;
+    align-items: center;
+    font-size: 15px;
+}
+
+.search-container {
+    flex: 6;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.search-container input {
+    width: 80%;
+    padding: 15px;
+    border: 1px solid #e1e1e1;
+    background-color: #f7f7f7;
+    border-radius: 10px;
+    margin-right: 10px;
+}
+
+.search-container button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 20px;
+    padding: 5px;
+}
+
+.icon-container {
+    flex: 1;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+}
+
+.icon-container button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    border : 1.5px solid #e5e5e5;
+    border-radius: 5px;
+    font-size: 15px;
+    padding : 10px;
+    margin: 0px 10px;
+}
+
+main {
+    display: flex;
+    flex-direction: row;
+    padding: 20px;
+    box-sizing: border-box;
+    flex-wrap: wrap; /*화면 크기에 따라 줄바꿈 되도록 설정 */
+}
+
+body, h1, h2, h3, p, div, button, input {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+
+body {
+    font-family: Arial, sans-serif;
+    background-color: #fff;
+    color: #000;
+}
+
+a {
+    text-decoration: none;
+    color: inherit;
+}
+

--- a/IntegrateLecture/lecture/static/css/review.css
+++ b/IntegrateLecture/lecture/static/css/review.css
@@ -1,0 +1,55 @@
+.lecture-review {
+    margin-bottom: 20px;
+    border-bottom: 4px solid #ededed;
+    background: #fff;
+    border-radius: 8px;
+}
+
+.review-container{
+    width: 100%;
+    height: 90%;
+    top : 20px;
+    background-color: #f9f9f9;
+    border: none;
+    border-radius: 15px;
+    padding : 20px;
+}
+
+.review-summary h3, .review-trends h3, .review-keywords h3, .review-sentiment h3 {
+    color: #001f3f; /* 네이비색 제목 */
+    margin-bottom: 10px;
+}
+
+.review-summary p, .review-trends, .review-keywords ul, .review-sentiment p {
+    color: #333; /* 텍스트 색상 */
+    margin-bottom: 10px;
+}
+
+.review-trends .bar-graph {
+    display: flex;
+    justify-content: space-around;
+    align-items: flex-end;
+    height: 100px;
+    margin-top: 10px;
+}
+
+.review-trends .bar {
+    width: 20px;
+    background-color: #4CAF50;
+}
+
+.review-keywords ul {
+    list-style: none;
+    padding: 0;
+}
+
+.review-keywords li {
+    background: #e3f2fd; /* 연한 파란색 배경 */
+    margin: 5px 0;
+    padding: 5px;
+    border-radius: 4px;
+}
+
+.review-sentiment p {
+    margin: 5px 0;
+}

--- a/IntegrateLecture/lecture/static/js/script.js
+++ b/IntegrateLecture/lecture/static/js/script.js
@@ -1,0 +1,99 @@
+$(document).ready(function() {
+
+    $('.tab-button').click(function () {
+        var target = $(this).data('target');
+        var targetOffset = $('#' + target).offset().top - $('.tab-container').height();
+
+        $('html, body').animate({
+            scrollTop: targetOffset
+        }, 500);
+
+        // 클릭된 탭 버튼에 active 클래스 추가
+        $('.tab-button').removeClass('active');
+        $(this).addClass('active');
+    });
+
+    // 스크롤 시 탭 활성 상태 업데이트
+    $(window).scroll(function () {
+        var scrollPos = $(window).scrollTop();
+        $('.tab-button').each(function () {
+            var target = $(this).data('target');
+            var targetOffset = $('#' + target).offset().top - $('.tab-container').height() - 10;
+
+            if (scrollPos >= targetOffset) {
+                $('.tab-button').removeClass('active');
+                $(this).addClass('active');
+            }
+        });
+    });
+
+    // what_do_i_learn 구분자 제거
+    var whatDoILearn = $('.lecture-whatlearn').data('contents');
+    var learns = whatDoILearn.split('|');
+    var learn_html = '';
+    learns.forEach(function(learn) {
+        learn_html += '<div class="item"> # ' + learn + '</div>';
+    });
+    $('#what-do-i-learn-container').html(learn_html);
+
+    // tag 구분자 제거
+    var tagData = $('.tags').data('contents');
+    var tags = tagData.split('|');
+    var tag_html = '';
+    tags.forEach(function(tag) {
+        tag_html += '<button>' + '#'+tag + '</button>';
+    });
+    $('.tags').html(tag_html);
+
+    var rating = parseFloat($('.lecture-rating').data('rating')); // rating 값을 data-attribute에서 가져옴
+    $('#rating-stars').html(getStarRatingHtml(rating));
+
+    $('#heart-icon, #sticky-heart-icon, #header-heart-icon').on('click', function() {
+        $(this).toggleClass('liked');
+        if ($(this).hasClass('liked')) {
+            $(this).removeClass('fa-regular fa-heart').addClass('fa-solid fa-heart');
+        } else {
+            $(this).removeClass('fa-solid fa-heart').addClass('fa-regular fa-heart');
+        }
+    });
+
+    $('.price').each(function() {
+        var price = $(this).text().replace('원', '').trim();
+        var formattedPrice = price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+        $(this).text(formattedPrice + '원');
+    });
+
+});
+
+function searchLecture() {
+    const query = encodeURIComponent(document.getElementById('searchInput').value.trim());
+    if (query) {
+        window.location.href = `/api/search/?q=${query}`;
+    }
+}
+
+function getStarRatingHtml(rating) {
+    const fullStar = '<i class="fa-solid fa-star"></i>';
+    const halfStar = '<i class="fa-regular fa-star-half-stroke"></i>';
+    const emptyStar = '<i class="fa-regular fa-star"></i>';
+    
+    let starsHtml = '';
+    let fullStars = Math.floor(rating);
+    let hasHalfStar = (rating % 1) >= 0.5;
+
+    for (let i = 0; i < fullStars; i++) {
+        starsHtml += fullStar+' ';
+    }
+
+    if (hasHalfStar) {
+        starsHtml += halfStar+' ';
+    }
+
+    const totalStars = 5;
+    const remainingStars = totalStars - fullStars - (hasHalfStar ? 1 : 0);
+    for (let i = 0; i < remainingStars; i++) {
+        starsHtml += emptyStar+' ';
+    }
+
+    return starsHtml;
+}

--- a/IntegrateLecture/lecture/templates/detail.html
+++ b/IntegrateLecture/lecture/templates/detail.html
@@ -1,0 +1,162 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ lecture.lecture_name }} - 강의 상세 정보</title>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="{% static 'css/layout.css' %}">
+    <link rel="stylesheet" href="{% static 'css/detail.css' %}">
+    <link rel="stylesheet" href="{% static 'css/review.css' %}">
+</head>
+<body>
+    <header>
+        <div class="header-container">
+            <div class="logo-container">
+                <p> 사이트 로고 </p>
+            <div class="search-container">
+                <input type="text" placeholder="원하는 강의를 검색해보세요." id="searchInput">
+                <button onclick="searchLecture()">
+                    <i class="fa-solid fa-magnifying-glass"></i>
+                </button>
+            </div>
+            <div class="icon-container">
+                {% comment %} <button><i id="heart-icon" class="fa-regular fa-heart"></i></button> {% endcomment %}
+                <button><a> 찜 목록 </a></button>
+                <button><a> 내 정보 </a></button>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <div class="lecture-summary">
+            <div class="summary-info">
+                <ul>
+                    {% for category in categories %}
+                        <li>{{ category.main_category_name }} / {{ category.mid_category_name }}</li>
+                    {% endfor %}
+                </ul>
+                <h1>{{ lecture.lecture_name }}</h1>
+                <br>
+                <p><i class="fa-solid fa-user-tie"></i> : {{ lecture.teacher }}</p>
+                <p class="lecture-rating" data-rating="{{ lecture.scope }}">
+                    <span id="rating-stars" class="rating-stars"></span> 
+                    ({{ lecture.scope }}) 수강평 {{ lecture.review_count }} 개
+                </p>
+                <div class="tags" data-contents="{{ lecture.tag }}">
+                    <!-- 버튼은 jQuery에서 동적으로 생성될 예정 -->
+                </div>
+            </div>
+            <div class="lecture-thumbnail">
+                <img src="{{ lecture.thumbnail_url }}" alt="썸네일">
+            </div>
+        </div>
+
+        <div class="lecture-content">
+            <div class="lecture-detail">
+                 <!-- 탭 버튼 -->
+                <div class="tab-container">
+                    <button class="tab-button" data-target="lecture-description">강의 소개</button>
+                    <button class="tab-button" data-target="lecture-whatlearn">이런걸 배워요</button>
+                    <button class="tab-button" data-target="lecture-review">리뷰 분석</button>
+                    <button class="tab-button" data-target="lecture-price-history">가격 히스토리</button>
+                </div>
+                <div id="lecture-description" class="lecture-description">
+                    <h2>강의 소개</h2>
+                    <br>
+                    <p style="line-height: 1.8;">{{ lecture.description }}</p>
+
+                </div>
+                <br>
+                <div id="lecture-whatlearn" class="lecture-whatlearn" data-contents="{{ lecture.what_do_i_learn }}">
+                    <h2>이런걸 배워요</h2>
+                    <br>
+                    <div id="what-do-i-learn-container"></div>
+                    <!-- 리스트는 jQuery에서 동적으로 생성될 예정 -->
+                </div>
+                <br>
+                <div id="lecture-review" class="lecture-review">
+                    <h2>리뷰 분석 결과 데이터</h2>  
+                    <br> 
+                    <div class="review-container"> 
+                        <!-- 별점 평균 및 리뷰 수 -->
+                        <div class="review-summary">
+                            <h3>별점 평균</h3>
+                            <p>4.5 / 5</p>
+                            <h3>총 리뷰 수</h3>
+                            <p>120개</p>
+                        </div>
+                        
+                        <!-- 리뷰 트렌드 그래프 (예시로 간단히 막대 그래프 형태로) -->
+                        <div class="review-trends">
+                            <h3>리뷰 트렌드</h3>
+                            <div class="bar-graph">
+                                <div class="bar" style="height: 80%; background-color: #4CAF50;"></div>
+                                <div class="bar" style="height: 60%; background-color: #2196F3;"></div>
+                                <div class="bar" style="height: 40%; background-color: #FF9800;"></div>
+                                <div class="bar" style="height: 20%; background-color: #F44336;"></div>
+                            </div>
+                        </div>
+                        
+                        <!-- 주요 키워드 -->
+                        <div class="review-keywords">
+                            <h3>주요 키워드</h3>
+                            <ul>
+                                <li>유익하다</li>
+                                <li>쉽다</li>
+                                <li>실용적</li>
+                                <li>친절하다</li>
+                                <li>전문적</li>
+                            </ul>
+                        </div>
+                        
+                        <!-- 감정 분석 -->
+                        <div class="review-sentiment">
+                            <h3>감정 분석</h3>
+                            <p>긍정적: 70%</p>
+                            <p>부정적: 20%</p>
+                            <p>중립적: 10%</p>
+                        </div>
+                    </div>
+                </div>
+                <br>
+                <div id="lecture-price-history" class="lecture-price-history">
+                    <h2>가격 히스토리</h2>
+                    <br>
+                    <!-- 가격 히스토리를 여기에 표시 -->
+                </div>
+            </div>
+            <div class="sticky-container">
+                <div class="sticky-title">
+                    <h3>Inflearn</h3>
+                </div>
+                <div class="sticky-text">
+                    <div class="info-discript">
+                        <span class="price">{{ lecture.price }}원</span>
+                        <a><i id="heart-icon" class="fa-regular fa-heart"></i>(1,345)</a>
+                    </div>
+                    <br>
+                    <a class="info"> 강의 레벨   </a> 
+                    <a>{{lecture.level}}</a>
+                </br></br>
+                    <a class="info"> 총 강의 시간   </a>
+                    <a>{{lecture.lecture_time}}</a>
+                </div>
+                <div class="sticky-button">
+                    <button class="num1">수강하러 가기</button>
+                    <button class="num2">장바구니 담기</button>
+                    <button class="num2">알림 설정하기</button>
+                </div>
+            </div>
+            <div class="fixed-card">
+                <button>수강하러 가기</button>
+                <button>강의 찜하기</button>
+            </div>
+        </div>
+    </main>
+
+    <script src="/static/js/script.js"></script>
+</body>
+</html>

--- a/IntegrateLecture/lecture/urls.py
+++ b/IntegrateLecture/lecture/urls.py
@@ -3,8 +3,10 @@ from . import views
 from .views import *
 
 urlpatterns = [
-    path('lecture/<str:pk>/', LectureDetailView.as_view(), name='lecture_detail'),
-    path('search/',LectureSearchView.as_view(),name='lecture_search'),
-    path("lecture/", LectureListView.as_view(), name="lecture_list"),
+    path('lecture/detail/<str:pk>/', LectureDetailTemplateView.as_view(), name='lecture_detail'),
+
+    path('api/detail/<str:pk>/', LectureDetailView.as_view(), name='lecture_detail'),
+    path('api/search/',LectureSearchView.as_view(),name='lecture_search'),
+    path('api/list/', LectureListView.as_view(), name='lecture_list'),
 ]
 


### PR DESCRIPTION
IntegrateLecture/lecture/static/css/detail_body.css : 상세페이지 body 하위 태그들의 css
IntegrateLecture/lecture/static/css/detail_header.css : 상세페이지 header 하위 태그들의 css
IntegrateLecture/lecture/static/css/detail_header.css : 강의 리뷰 분석 예시 이미지를 위한 더미 코드
IntegrateLecture/lecture/static/js/script.js : 상세페이지 내부 모든 요소들의 js
IntegrateLecture/lecture/templates/detail.html : 상세페이지 html 코드
IntegrateLecture/lecture/urls.py : api/ 하위 페이지들의 경로 탐색 에러로 인해 url 경로 재지정

그 외 변경 요소는 develop 요소 pull 과정에서 생긴 변동사항임

html 구현 상황

강의 아이디값을 인자로 주었을 때, 해당 강의에 대한 세부 정보 제공
현재 리뷰 분석과, 가격 히스토리 컨테이너는 기능 구현이 완료되지 않아 더미를 넣거나 공란으로 둠
강의 가격 옆 하트 아이콘의 숫자는 현재 더미값임. 강의 사이트의 리뷰 개수와는 별개로 현재 웹에서 해당 강의를 찜한 유저 수를 표시하고자 함
찜 목록, 내 정보 요소역시 더미값. 유저 기능 구현 완료 시 수정 예정
검색시 관련 강의들이 뜨는 화면을 구현하지 못해서 현재는 api 페이지로 넘어감
그 외에도 카테고리, 강사명, 태그 클릭 시 해당 단어를 키워드로 하는 검색 화면으로 넘어가게끔 구현 예정
스티키 카드의 수강, 장바구니, 알림 버튼 역시 현재는 기능 구현이 완료 되지 않아서 요소만 존재
jira Issue_id : OL_113