### PR TITLE
정보가 부족한 강의 리스팅에서 제거하기

### DIFF
--- a/IntegrateLecture/lecture/models.py
+++ b/IntegrateLecture/lecture/models.py
@@ -18,7 +18,9 @@ class Category(models.Model):
 
 class LectureInfo(models.Model):
     lecture_id = models.CharField(primary_key=True, max_length=255)
+    lecture_url = models.CharField(max_length=511, blank=True, null=True)
     lecture_name = models.CharField(max_length=255, blank=True, null=True)
+    origin_price = models.IntegerField(blank=True, null=True)
     price = models.IntegerField(blank=True, null=True)
     description = models.TextField(blank=True, null=True)
     what_do_i_learn = models.TextField(blank=True, null=True)

--- a/IntegrateLecture/lecture/static/js/all_lec.js
+++ b/IntegrateLecture/lecture/static/js/all_lec.js
@@ -108,10 +108,38 @@ async function fetchLectures(page) {
     return data;
 }
 
+function checkUrl(strUrl) {
+    let expUrl = /^http[s]?:\/\/([\S]{3,})/i;
+    return expUrl.test(strUrl);
+}
+
+function checkLectureData(lecture) {
+    if (!checkUrl(lecture.lecture_url) || !checkUrl(lecture.thumbnail_url))
+        return false;
+    if (lecture.platform_name !== "coursera") {
+        if (lecture.origin_price == null || lecture.price == null)
+            return false;
+    }
+    if (lecture.description == null || lecture.description === "")
+        return false;
+    if (lecture.what_do_i_learn == null || lecture.what_do_i_learn === "")
+        return false;
+    return true;
+}
 
 function renderLectures(lectures) {
     lectureListElement.innerHTML = '';
     lectures.forEach(lecture => {
+        if (!checkLectureData(lecture)) {
+            console.log(lecture.lecture_url + " " + checkUrl(lecture.lecture_url))
+            console.log(lecture.thumbnail_url + " " + checkUrl(lecture.thumbnail_url))
+            console.log(lecture.platform_name + " " + lecture.origin_price + " " + lecture.price)
+            console.log("description: " + lecture.description)
+            console.log("what do i learn: " + lecture.what_do_i_learn)
+            console.log(lecture.lecture_name + " was except from lecture list");
+            return;
+        }
+
         const lectureElement = document.createElement('div');
         lectureElement.classList.add('lecture-item');
         lectureElement.dataset.lectureId = lecture.lecture_id;


### PR DESCRIPTION
최신 DB에 맞도록 models.py를 수정하고 정보가 부족한 강의 리스팅에서 제거

- lecture_url & thumbnail_url이 url 형태이어야 함
- platform이 coursera가 아닌 경우 origin_price와 lecture_price가 null이 아니어야 함
- description과 what_do_i_learn가 null이거나 아무 데이터도 없지 않아야 함